### PR TITLE
updated the webmap from v2.13 to v2.27 to solve re-transmit

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "node-red-contrib-multifeed-parser": "0.0.3",
         "node-red-contrib-telegrambot": "~9.2.1",
-        "node-red-contrib-web-worldmap": "~2.13.2",
+        "node-red-contrib-web-worldmap": "~2.27.0",
         "node-red-contrib-zip": "~1.0.0",
         "node-red-dashboard": "~2.28.2",
         "request": "^2.88.2"


### PR DESCRIPTION
dcj on discord solved an isue where the webmap did not pickup old broadcast data. that fix was published in node-red package v2.27.